### PR TITLE
docs: reescribir requisitos con estandares

### DIFF
--- a/docs/project-mangement/02. feature-requirements.md
+++ b/docs/project-mangement/02. feature-requirements.md
@@ -2,7 +2,13 @@
 
 ## Alcance
 
-Este documento especifica los requisitos funcionales y no funcionales del MVP de SimRacing Shop, una plataforma e-commerce para productos de sim racing personalizables con configurador 3D.
+Este documento especifica los requisitos funcionales y no funcionales del MVP de SimRacing Shop, una plataforma e-commerce para productos de sim racing personalizables con configurador 3D. 
+
+Utilizando estructuras como:
+- **Who - What - Why** para historias de usuario
+- **Given - When - Then** para los criterios de aceptación
+
+Técnicas y principios como **MoSCoW** e **INVEST** así como objetivos medibles.
 
 ---
 


### PR DESCRIPTION
Formatear los requisitos adecuadamente 
- Separar requisitos funcionales (RF-001 a RF-050) de no funcionales (RNF-001 a RNF-020)
 - Aplicar patrón Who-What-Why en historias de usuario
 - Implementar priorización MoSCoW (Must/Should/Could/Won't)
 - Usar formato Given-When-Then en criterios de aceptación
 - Añadir límites medibles en requisitos no funcionales
 - Estructurar fichas con ID, Prioridad y Descripción