### PR TITLE
ci: hacer que no se ejecute el CI con cambios de documentación

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".gitignore"
+      - "LICENSE"
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".gitignore"
+      - "LICENSE"
 
 env:
   DOTNET_VERSION: "10.0.x"


### PR DESCRIPTION
 Ahora el CI no se ejecutará cuando los únicos cambios sean en:

  - docs/** - Toda la carpeta de documentación
  - **.md - Archivos markdown en cualquier ubicación (README, CHANGELOG, etc.)
  - .gitignore
  - LICENSE

  Resultado: Si haces un commit que solo modifica archivos de documentación, el CI se saltará
  automáticamente, ahorrando tiempo y recursos de GitHub Actions.