### PR TITLE
ci(sonarcloud): integrar análisis de código para frontend y backend (…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,12 +219,133 @@ jobs:
           path: frontend/.next
 
   # ============================================
+  # SONARCLOUD ANALYSIS
+  # ============================================
+  backend-sonar:
+    name: Backend - SonarCloud
+    runs-on: ubuntu-latest
+    needs: [backend-test]
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Java (required by SonarScanner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage
+
+      - name: Install SonarScanner for .NET
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Begin SonarCloud analysis
+        run: |
+          dotnet sonarscanner begin \
+            /k:"simracing-shop-backend" \
+            /o:"${{ vars.SONAR_ORGANIZATION }}" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cs.opencover.reportsPaths="coverage/**/coverage.cobertura.xml" \
+            /d:sonar.exclusions="**/Migrations/**,**/obj/**,**/bin/**,**/*.Designer.cs" \
+            /d:sonar.coverage.exclusions="**/Migrations/**,**/Program.cs,**/*Tests/**" \
+            /d:sonar.cpd.exclusions="**/Migrations/**"
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: End SonarCloud analysis
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  frontend-sonar:
+    name: Frontend - SonarCloud
+    runs-on: ubuntu-latest
+    needs: [frontend-test]
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: frontend
+          args: >
+            -Dsonar.projectKey=simracing-shop-frontend
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+            -Dsonar.sources=src
+            -Dsonar.tests=tests
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/node_modules/**,.next/**,coverage/**,**/*.config.*
+            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,tests/**,**/*.config.*
+            -Dsonar.typescript.tsconfigPath=tsconfig.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  # ============================================
   # SUMMARY
   # ============================================
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [backend-build, frontend-build]
+    needs: [backend-build, frontend-build, backend-sonar, frontend-sonar]
     if: success()
 
     steps:

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -1,0 +1,23 @@
+# SonarCloud Configuration - Frontend
+sonar.projectKey=simracing-shop-frontend
+sonar.projectName=SimRacing Shop - Frontend
+
+# Source configuration
+sonar.sources=src
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# Exclusions from analysis
+sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/node_modules/**,.next/**,coverage/**,**/*.config.*
+
+# Coverage exclusions
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,tests/**,**/*.config.*
+
+# Duplication exclusions
+sonar.cpd.exclusions=**/messages/**,**/*.json
+
+# Coverage report path (LCOV format)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# TypeScript configuration
+sonar.typescript.tsconfigPath=tsconfig.json

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     exclude: ['node_modules', 'dist', '.next', 'tests/e2e'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       exclude: [
         'node_modules/',
         'tests/',


### PR DESCRIPTION
…#16)

* ci(sonarcloud): integrar análisis de código para frontend y backend

Añade SonarCloud como herramienta de análisis estático de código con proyectos independientes para frontend y backend, reutilizando los reportes de coverage existentes.



* fix(sonarcloud): eliminar sonar-project.properties incompatible con .NET scanner

SonarScanner for .NET no soporta archivos sonar-project.properties. Se elimina el archivo y se mueve la configuración cpd.exclusions al workflow.



---------