### PR TITLE
feat(health): añadir endpoint /health con .NET Health Checks Middleware

### DIFF
--- a/backend/src/SimRacingShop.API/HealthChecks/RedisHealthCheck.cs
+++ b/backend/src/SimRacingShop.API/HealthChecks/RedisHealthCheck.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+
+namespace SimRacingShop.API.HealthChecks;
+
+public class RedisHealthCheck(IConnectionMultiplexer redis) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var db = redis.GetDatabase();
+            await db.PingAsync();
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Redis no disponible", ex);
+        }
+    }
+}

--- a/backend/src/SimRacingShop.API/SimRacingShop.API.csproj
+++ b/backend/src/SimRacingShop.API/SimRacingShop.API.csproj
@@ -18,6 +18,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.2" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />


### PR DESCRIPTION
Registra checks de PostgreSQL (EF Core) y Redis, con respuesta JSON detallada por check. Necesario para el health check de Railway.