### PR TITLE
fix(deploy): aplicar migraciones EF Core automáticamente al arrancar

### DIFF
--- a/backend/src/SimRacingShop.API/Program.cs
+++ b/backend/src/SimRacingShop.API/Program.cs
@@ -341,6 +341,7 @@ try
         var logger = services.GetRequiredService<ILogger<Program>>();
         var adminSettings = builder.Configuration.GetSection("AdminSeed").Get<AdminSeedSettings>() ?? new AdminSeedSettings();
 
+        await context.Database.MigrateAsync();
         await DbInitializer.SeedAsync(userManager, roleManager, adminSettings, logger);
         await ShippingZoneSeeder.SeedAsync(context, logger);
     }


### PR DESCRIPTION
Añade MigrateAsync() en el startup para que Railway aplique las migraciones pendientes sin intervención manual.