### PR TITLE
fix(docker): instalar libgssapi-krb5-2 en imagen runtime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,7 @@ RUN dotnet publish src/SimRacingShop.API/SimRacingShop.API.csproj \
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends libgssapi-krb5-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/out .
 RUN useradd -r -s /bin/false appuser && chown -R appuser /app
 USER appuser


### PR DESCRIPTION
Npgsql requiere esta librería en Linux para inicializar el driver de PostgreSQL. La imagen aspnet:10.0 no la incluye por defecto.