### PR TITLE
fix(cart): enviar X-Cart-Session siempre en usuarios anónimos

### DIFF
--- a/frontend/src/lib/api/cart.ts
+++ b/frontend/src/lib/api/cart.ts
@@ -28,10 +28,11 @@ export const ensureSessionId = (): string => {
   return newId;
 };
 
-// Returns X-Cart-Session header if a session exists (ignored by backend when user is authenticated)
+// Ensures an anonymous session ID exists and returns it as header.
+// Ignored by the backend when the user is authenticated.
 const sessionHeaders = () => {
-  const sessionId = getSessionId();
-  return sessionId ? { "X-Cart-Session": sessionId } : {};
+  const sessionId = ensureSessionId();
+  return { "X-Cart-Session": sessionId };
 };
 
 export const cartApi = {

--- a/frontend/tests/unit/lib/api/cart.test.ts
+++ b/frontend/tests/unit/lib/api/cart.test.ts
@@ -94,15 +94,16 @@ describe("cartApi", () => {
       );
     });
 
-    it("omits X-Cart-Session header when no session ID", async () => {
+    it("crea y envía X-Cart-Session cuando no hay sesión previa", async () => {
       vi.mocked(apiClient.get).mockResolvedValue({ data: emptyMockCart() });
 
       await cartApi.getCart();
 
-      expect(apiClient.get).toHaveBeenCalledWith(
-        "/cart",
-        expect.objectContaining({ headers: {} })
-      );
+      const [, opts] = vi.mocked(apiClient.get).mock.calls[0];
+      const header = (opts as { headers: Record<string, string> }).headers["X-Cart-Session"];
+      expect(header).toBeTruthy();
+      // El ID generado debe haberse guardado en localStorage
+      expect(localStorage.getItem(SESSION_KEY)).toBe(header);
     });
 
     it("defaults locale to es", async () => {


### PR DESCRIPTION
sessionHeaders() llamaba a getSessionId() que devuelve null para nuevos visitantes, dejando la cabecera vacía y causando 400 en el backend. Se cambia a ensureSessionId() para que el UUID se cree automáticamente en la primera llamada. Se actualiza el test que esperaba headers:{} para verificar que se genera y almacena el ID en localStorage.