### PR TITLE
fix(productos): mostrar botón 'Añadir al carrito' en productos no personalizables

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -228,6 +228,7 @@
     "inStock": "In stock",
     "outOfStock": "Out of stock",
     "customize": "CUSTOMIZE",
+    "addToCart": "ADD TO CART",
     "productionTime": "Production time: {days} days",
     "weight": "Weight: {grams}g",
     "specifications": "Technical Specifications",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -228,6 +228,7 @@
     "inStock": "En stock",
     "outOfStock": "Agotado",
     "customize": "PERSONALIZAR",
+    "addToCart": "AÑADIR AL CARRITO",
     "productionTime": "Tiempo de producción: {days} días",
     "weight": "Peso: {grams}g",
     "specifications": "Especificaciones técnicas",

--- a/frontend/src/app/[locale]/productos/[slug]/ProductDetailContent.tsx
+++ b/frontend/src/app/[locale]/productos/[slug]/ProductDetailContent.tsx
@@ -84,6 +84,15 @@ export function ProductDetailContent({ slug }: Props) {
           <ProductInfo
             product={product}
             onCustomize={() => setConfiguratorOpen(true)}
+            onAddToCart={async () => {
+              setIsAddingToCart(true);
+              try {
+                await addItem(product.id, 1, locale, [], []);
+              } finally {
+                setIsAddingToCart(false);
+              }
+            }}
+            isAddingToCart={isAddingToCart}
           />
         </div>
 

--- a/frontend/src/components/products/ProductInfo.tsx
+++ b/frontend/src/components/products/ProductInfo.tsx
@@ -9,9 +9,11 @@ import type { ProductDetail } from "@/types/products";
 type Props = {
   product: ProductDetail;
   onCustomize?: () => void;
+  onAddToCart?: () => void;
+  isAddingToCart?: boolean;
 };
 
-export function ProductInfo({ product, onCustomize }: Props) {
+export function ProductInfo({ product, onCustomize, onAddToCart, isAddingToCart }: Props) {
   const t = useTranslations("productDetail");
 
   const priceWithVat = product.basePrice * (1 + product.vatRate / 100);
@@ -102,14 +104,23 @@ export function ProductInfo({ product, onCustomize }: Props) {
         </p>
       )}
 
-      {/* Customize button */}
-      {product.isCustomizable && (
+      {/* CTA button */}
+      {product.isCustomizable ? (
         <Button
           size="lg"
           onClick={onCustomize}
           className="w-full bg-racing-red text-base font-semibold uppercase tracking-wider text-white hover:bg-racing-red/80 sm:w-auto"
         >
           {t("customize")}
+        </Button>
+      ) : (
+        <Button
+          size="lg"
+          onClick={onAddToCart}
+          disabled={isAddingToCart}
+          className="w-full bg-racing-red text-base font-semibold uppercase tracking-wider text-white hover:bg-racing-red/80 sm:w-auto"
+        >
+          {t("addToCart")}
         </Button>
       )}
 

--- a/frontend/tests/components/ProductDetailContent.test.tsx
+++ b/frontend/tests/components/ProductDetailContent.test.tsx
@@ -224,6 +224,39 @@ describe("ProductDetailContent", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("shows ADD TO CART button for non-customizable products", async () => {
+      const product = createMockProductDetail({ isCustomizable: false });
+      vi.mocked(productsApi.getProductBySlug).mockResolvedValue(product);
+
+      render(<ProductDetailContent slug="test" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "ADD TO CART" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("clicking ADD TO CART calls addItem with empty component arrays for non-customizable products", async () => {
+      const mockAddItem = vi.fn().mockResolvedValue(undefined);
+      useCartStore.setState({ addItem: mockAddItem } as never);
+
+      const product = createMockProductDetail({ isCustomizable: false, id: "prod-nc" });
+      vi.mocked(productsApi.getProductBySlug).mockResolvedValue(product);
+      const user = userEvent.setup();
+
+      render(<ProductDetailContent slug="test" />);
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "ADD TO CART" })).toBeInTheDocument()
+      );
+      await user.click(screen.getByRole("button", { name: "ADD TO CART" }));
+
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith("prod-nc", 1, "en", [], []);
+      });
+    });
+
     it("opens the configurator overlay when CUSTOMIZE is clicked", async () => {
       const product = createMockProductDetail({ isCustomizable: true });
       vi.mocked(productsApi.getProductBySlug).mockResolvedValue(product);

--- a/frontend/tests/components/ProductInfo.test.tsx
+++ b/frontend/tests/components/ProductInfo.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "../helpers/render";
+import userEvent from "@testing-library/user-event";
 import { ProductInfo } from "@/components/products/ProductInfo";
 import { createMockProductDetail } from "../helpers/products";
 
@@ -82,16 +83,43 @@ describe("ProductInfo", () => {
       ).toBeInTheDocument();
     });
 
-    it("does not show badge or button when product is not customizable", () => {
-      const product = createMockProductDetail({
-        isCustomizable: false,
-      });
+    it("does not show 'Customizable' badge or CUSTOMIZE button when product is not customizable", () => {
+      const product = createMockProductDetail({ isCustomizable: false });
       render(<ProductInfo product={product} />);
 
       expect(screen.queryByText("Customizable")).not.toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "CUSTOMIZE" })
       ).not.toBeInTheDocument();
+    });
+
+    it("shows ADD TO CART button when product is not customizable", () => {
+      const product = createMockProductDetail({ isCustomizable: false });
+      render(<ProductInfo product={product} />);
+
+      expect(
+        screen.getByRole("button", { name: "ADD TO CART" })
+      ).toBeInTheDocument();
+    });
+
+    it("calls onAddToCart when ADD TO CART button is clicked", async () => {
+      const user = userEvent.setup();
+      const onAddToCart = vi.fn();
+      const product = createMockProductDetail({ isCustomizable: false });
+      render(<ProductInfo product={product} onAddToCart={onAddToCart} />);
+
+      await user.click(screen.getByRole("button", { name: "ADD TO CART" }));
+
+      expect(onAddToCart).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables ADD TO CART button when isAddingToCart is true", () => {
+      const product = createMockProductDetail({ isCustomizable: false });
+      render(<ProductInfo product={product} isAddingToCart={true} />);
+
+      expect(
+        screen.getByRole("button", { name: "ADD TO CART" })
+      ).toBeDisabled();
     });
   });
 


### PR DESCRIPTION


- ProductInfo muestra el botón PERSONALIZAR si isCustomizable, o AÑADIR AL CARRITO si no
- ProductDetailContent pasa onAddToCart e isAddingToCart a ProductInfo
- Añadidas claves de traducción productDetail.addToCart en es.json y en.json
- Tests: 4 nuevos en ProductInfo y 2 nuevos en ProductDetailContent