### PR TITLE
fix(auth): vaciar el carrito al cerrar sesión

### DIFF
--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { AuthStore, AuthResponseDto, UserDto } from "@/types/auth";
 import { setStoredTokens, clearStoredTokens } from "@/lib/api-client";
+import { useCartStore } from "@/stores/cart-store";
 
 const initialState = {
   user: null,
@@ -41,6 +42,9 @@ export const useAuthStore = create<AuthStore>()(
       logout: () => {
         // Clear tokens from apiClient localStorage
         clearStoredTokens();
+
+        // Clear cart so the user's items are not visible after logout
+        useCartStore.getState().reset();
 
         set({
           ...initialState,

--- a/frontend/tests/unit/stores/auth-store.test.ts
+++ b/frontend/tests/unit/stores/auth-store.test.ts
@@ -1,9 +1,12 @@
 import { useAuthStore } from "@/stores/auth-store";
+import { useCartStore } from "@/stores/cart-store";
 import { resetAuthStore, createMockAuthResponse } from "../../helpers/auth-store";
+import { createMockCart, resetCartStore } from "../../helpers/cart";
 
 describe("auth-store", () => {
   beforeEach(() => {
     resetAuthStore();
+    resetCartStore();
     localStorage.clear();
   });
 
@@ -68,6 +71,15 @@ describe("auth-store", () => {
       expect(state.refreshToken).toBeNull();
       expect(state.isAuthenticated).toBe(false);
       expect(state.isLoading).toBe(false);
+    });
+
+    it("vacía el carrito al cerrar sesión", () => {
+      useCartStore.setState({ cart: createMockCart() });
+
+      useAuthStore.getState().setAuth(createMockAuthResponse());
+      useAuthStore.getState().logout();
+
+      expect(useCartStore.getState().cart).toBeNull();
     });
   });
 


### PR DESCRIPTION
- logout() llama a useCartStore.getState().reset() para limpiar el estado del carrito
- Al volver a iniciar sesión, LoginForm ya llama a mergeCart y restaura el carrito del usuario
- Test: verifica que cart queda null tras logout